### PR TITLE
copy of the object value

### DIFF
--- a/dist/angular-base64-upload.js
+++ b/dist/angular-base64-upload.js
@@ -1,6 +1,6 @@
-/*! angular-base64-upload - v0.0.2 - 2014-10-30
+/*! angular-base64-upload - v0.0.2 - 2015-01-26
 * https://github.com/adonespitogo/angular-base64-upload
-* Copyright (c) Adones Pitogo <pitogo.adones@gmail.com> 2014; Licensed  */
+* Copyright (c) Adones Pitogo <pitogo.adones@gmail.com> 2015; Licensed  */
 angular.module('naif.base64', [])
 .directive('baseSixtyFourInput', ['$window', function ($window) {
   return {

--- a/dist/angular-base64-upload.min.js
+++ b/dist/angular-base64-upload.min.js
@@ -1,4 +1,4 @@
-/*! angular-base64-upload - v0.0.2 - 2014-10-30
+/*! angular-base64-upload - v0.0.2 - 2015-01-26
 * https://github.com/adonespitogo/angular-base64-upload
-* Copyright (c) Adones Pitogo <pitogo.adones@gmail.com> 2014; Licensed  */
+* Copyright (c) Adones Pitogo <pitogo.adones@gmail.com> 2015; Licensed  */
 angular.module("naif.base64",[]).directive("baseSixtyFourInput",["$window",function(a){return{restrict:"A",require:"ngModel",link:function(b,c,d,e){function f(b){for(var c="",d=new Uint8Array(b),e=d.byteLength,f=0;e>f;f++)c+=String.fromCharCode(d[f]);return a.btoa(c)}var g={};b.readerOnload=function(a){var c=f(a.target.result);g.base64=c,b.$apply(function(){e.$setViewValue(g)})};var h=new FileReader;h.onload=b.readerOnload,c.on("change",function(){var a=c[0].files[0];g.filetype=a.type,g.filename=a.name,g.filesize=a.size,h.readAsArrayBuffer(a)})}}}]);

--- a/src/angular-base64-upload.js
+++ b/src/angular-base64-upload.js
@@ -10,7 +10,7 @@ angular.module('naif.base64', [])
         var base64 = _arrayBufferToBase64(e.target.result);
         fileObject.base64 = base64;
         scope.$apply(function(){
-          ngModel.$setViewValue(fileObject);
+          ngModel.$setViewValue(angular.copy(fileObject));
         });
       };
 


### PR DESCRIPTION
If the new value is an object (rather than a string or a number), we should make a copy of the object before passing it to `$setViewValue`. This is because `ngModel` does not perform a deep watch of objects, it only looks for a change of identity. If you only change the property of the object then `ngModel` will not realise that the object has changed and will not invoke the `$parsers` and `$validators` pipelines.

from https://docs.angularjs.org/api/ng/type/ngModel.NgModelController#$setViewValue