### PR TITLE
Removed bower and grunt-cli from dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./dist/angular-base64-upload');
+module.exports = 'naif.base64';

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Angular directive for uploading base64-encoded files that you can pass along with the resource model.",
   "main": "angular-base64-upload.js",
   "dependencies": {
-    "bower": "^1.3.12",
-    "grunt-cli": "^0.1.13"
   },
   "devDependencies": {
+    "bower": "^1.3.12",
+    "grunt-cli": "^0.1.13",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-base64-upload",
   "version": "v0.0.8",
   "description": "Angular directive for uploading base64-encoded files that you can pass along with the resource model.",
-  "main": "angular-base64-upload.js",
+  "main": "index.js",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
For such a small script, it shouldn't be expected to download bower and grunt-cli as neither of these are used. These should be in dev dependencies. Otherwise a ton of unnecessary stuff is installed when it should just be a tiny angular module.