### PR TITLE
remove tampering with form state

### DIFF
--- a/src/angular-base64-upload.js
+++ b/src/angular-base64-upload.js
@@ -43,10 +43,6 @@
             return;
           }
 
-          // need set falsy to activate required state when user predefines value for model
-          ngModel.$setViewValue(null);
-          ngModel.$setPristine();
-
           var rawFiles = [];
           var fileObjects = [];
 

--- a/test/angular-base64-upload.spec.js
+++ b/test/angular-base64-upload.spec.js
@@ -462,6 +462,17 @@ describe('AngularBase64Upload', function(){
           });
       });
 
+      describe('Input ngModel controller', function () {
+
+        it('should not tamper with dirty or pristine flags of his parent form', function () {
+
+          var d = _compile({ngModel: 'files'});
+
+          expect(d.$scope.form.$dirty).toBe(false);
+          expect(d.$scope.form.$pristine).toBe(true);
+        });
+      });
+
     });
 
   });


### PR DESCRIPTION
this PR reverts #47, which is causing any form containing a `base-sixty-four-input` being initialized with `$dirty = true` and `$pristine = false`.

i don't know what's the deal with that change in #47, because removing it still makes the tests pass.
