### PR TITLE
Update model only once all files are loaded to have a single angular event

### DIFF
--- a/src/angular-base64-upload.js
+++ b/src/angular-base64-upload.js
@@ -135,7 +135,9 @@
 
               promise.then(function (fileObj) {
                 fileObjects.push(fileObj);
-                _setViewValue();
+                // update model only once all files are loaded to have a single angular event
+                if (rawFiles.length == fileObjects.length)
+                  _setViewValue();
 
                 // fulfill the promise here.
                 file.deferredObj.resolve();


### PR DESCRIPTION
If we are selecting multiple files, multiple angular update model events will be raised consequently. Every one will contain an incrementing number of files loaded. I guess it is better to have a single model update event or maybe enable it with a flag