### PR TITLE
Export module name for use with CommonJS syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
-module.exports = require('./src/angular-base64-upload.js');
+require('./src/angular-base64-upload.js');
+module.exports = 'naif.base64';


### PR DESCRIPTION
#35 added support for browserify, but it doesn't correctly export the angular module symbol. this is important when you want to `require()` directly in the module list:

```js
angular
  .module('app', [
    require('angular-base64-upload')
  ]);
```