### PR TITLE
Typo in onerror event handler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Events
 
 Example event handler implementation:
    ```
-   $scope.errorHandler = function (event, reader, file fileList, fileObjs, object) {
+   $scope.errorHandler = function (event, reader, file, fileList, fileObjs, object) {
      console.log("An error occurred while reading file: "+file.name);
      reader.abort();
    };

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Events
 
 Example event handler implementation:
    ```
-   $scope.errorHandler = function (event, reader, fileList, fileObjs, file) {
+   $scope.errorHandler = function (event, reader, file fileList, fileObjs, object) {
      console.log("An error occurred while reading file: "+file.name);
      reader.abort();
    };


### PR DESCRIPTION
The example had a wrong number and order of parameters (compared to the onerror parameter description above).